### PR TITLE
list pages before folders in the index [RFC]

### DIFF
--- a/index.go
+++ b/index.go
@@ -1,16 +1,41 @@
 package index
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
+
+// NodeSortingWeight determines the sorting weights for elements
+// in a []Node slice
+type NodeSortingWeight int
+
+const (
+	PageSortingWeight NodeSortingWeight = iota
+	FolderSortingWeight
+)
 
 type Node interface {
+	SortingWeight() NodeSortingWeight
 	Value() string
 	Children() []Node
 	renderIndex(int) string
 }
 
+// ByWeight implements the sort.Interface for []Node based
+// on the SortingWeight of the elements
+type ByWeight []Node
+
+func (ns ByWeight) Len() int           { return len(ns) }
+func (ns ByWeight) Swap(i, j int)      { ns[i], ns[j] = ns[j], ns[i] }
+func (ns ByWeight) Less(i, j int) bool { return ns[i].SortingWeight() < ns[j].SortingWeight() }
+
 type Page struct {
 	Title string
 	Body  string
+}
+
+func (p Page) SortingWeight() NodeSortingWeight {
+	return PageSortingWeight
 }
 
 func (p Page) Value() string {
@@ -30,11 +55,16 @@ type Folder struct {
 	Contents []Node
 }
 
+func (f Folder) SortingWeight() NodeSortingWeight {
+	return FolderSortingWeight
+}
+
 func (f Folder) Value() string {
 	return f.Name
 }
 
 func (f Folder) Children() []Node {
+	sort.Sort(ByWeight(f.Contents))
 	return f.Contents
 }
 

--- a/index.go
+++ b/index.go
@@ -10,7 +10,7 @@ import (
 type NodeSortingWeight int
 
 const (
-	PageSortingWeight NodeSortingWeight = iota
+	PageSortingWeight NodeSortingWeight = iota // Pages come before Folders
 	FolderSortingWeight
 )
 
@@ -43,6 +43,7 @@ func (p Page) Value() string {
 }
 
 func (p Page) Children() []Node {
+	// a Page has no Children
 	return []Node{}
 }
 

--- a/index.go
+++ b/index.go
@@ -10,8 +10,8 @@ import (
 type NodeSortingWeight int
 
 const (
-	PageSortingWeight NodeSortingWeight = iota // Pages come before Folders
-	FolderSortingWeight
+	PageSortingWeight NodeSortingWeight = iota // Pages come before Directories
+	DirectorySortingWeight
 )
 
 type Node interface {
@@ -30,8 +30,7 @@ func (ns ByWeight) Swap(i, j int)      { ns[i], ns[j] = ns[j], ns[i] }
 func (ns ByWeight) Less(i, j int) bool { return ns[i].SortingWeight() < ns[j].SortingWeight() }
 
 type Page struct {
-	Title string
-	Body  string
+	Name string
 }
 
 func (p Page) SortingWeight() NodeSortingWeight {
@@ -39,7 +38,7 @@ func (p Page) SortingWeight() NodeSortingWeight {
 }
 
 func (p Page) Value() string {
-	return p.Title
+	return p.Name
 }
 
 func (p Page) Children() []Node {
@@ -48,28 +47,28 @@ func (p Page) Children() []Node {
 }
 
 func (p Page) renderIndex(d int) string {
-	return fmt.Sprintf("<li>%s</li>\n", p.Title)
+	return fmt.Sprintf("<li>%s</li>\n", p.Name)
 }
 
-type Folder struct {
+type Directory struct {
 	Name     string
 	Contents []Node
 }
 
-func (f Folder) SortingWeight() NodeSortingWeight {
-	return FolderSortingWeight
+func (f Directory) SortingWeight() NodeSortingWeight {
+	return DirectorySortingWeight
 }
 
-func (f Folder) Value() string {
+func (f Directory) Value() string {
 	return f.Name
 }
 
-func (f Folder) Children() []Node {
+func (f Directory) Children() []Node {
 	sort.Sort(ByWeight(f.Contents))
 	return f.Contents
 }
 
-func (f Folder) renderIndex(startingDepth int) string {
+func (f Directory) renderIndex(startingDepth int) string {
 	renderedChildren := ""
 	for _, c := range f.Children() {
 		renderedChildren += c.renderIndex(startingDepth + 1)

--- a/index_test.go
+++ b/index_test.go
@@ -4,7 +4,7 @@ import "testing"
 import "github.com/stretchr/testify/assert"
 
 func TestRenderIndexForEmptyFolder(t *testing.T) {
-	f := Folder{
+	f := Directory{
 		Name:     "foo",
 		Contents: []Node{},
 	}
@@ -17,19 +17,19 @@ func TestRenderIndexForEmptyFolder(t *testing.T) {
 }
 
 func TestRenderIndex(t *testing.T) {
-	f := Folder{
+	f := Directory{
 		Name: "root",
 		Contents: []Node{
-			Page{Title: "root_file.org"},
-			Folder{
+			Page{Name: "root_file.org"},
+			Directory{
 				Name: "level1",
 				Contents: []Node{
-					Page{Title: "level1_file.md"},
-					Folder{
+					Page{Name: "level1_file.md"},
+					Directory{
 						Name: "level2",
 						Contents: []Node{
-							Page{Title: "level2_file.md"},
-							Page{Title: "level2_other_file.md"},
+							Page{Name: "level2_file.md"},
+							Page{Name: "level2_other_file.md"},
 						},
 					},
 				},
@@ -53,11 +53,11 @@ func TestRenderIndex(t *testing.T) {
 }
 
 func TestRenderIndexRendersPagesBeforeFolders(t *testing.T) {
-	f := Folder{
+	f := Directory{
 		Name: "foo",
 		Contents: []Node{
-			Folder{Name: "folder"},
-			Page{Title: "page"},
+			Directory{Name: "folder"},
+			Page{Name: "page"},
 		},
 	}
 

--- a/index_test.go
+++ b/index_test.go
@@ -51,3 +51,23 @@ func TestRenderIndex(t *testing.T) {
 
 	assert.Equal(t, expected, actual, "should be the same")
 }
+
+func TestRenderIndexRendersPagesBeforeFolders(t *testing.T) {
+	f := Folder{
+		Name: "foo",
+		Contents: []Node{
+			Folder{Name: "folder"},
+			Page{Title: "page"},
+		},
+	}
+
+	actual := RenderIndex(f)
+
+	expected := "<ul>\n"
+	expected += "<li><h1>foo</h1></li>\n"
+	expected += "<li>page</li>\n"
+	expected += "<li><h2>folder</h2></li>\n"
+	expected += "</ul>"
+
+	assert.Equal(t, expected, actual, "should be the same")
+}


### PR DESCRIPTION
Files/pages should are now listed before folders in the index.

For example, in a folder structure like this one:
```
.
├── bar
│   └── baz.md
└── foo.md
```
the rendered index resembles:
> - foo
>
> **# bar**
> - baz